### PR TITLE
Makefile: only check ICU_FLAGS (ICU_LIBS seems to be empty)

### DIFF
--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -53,11 +53,7 @@ else
 	ICU_LIBS = $(shell pkg-config --libs icu-uc icu-io)
 endif
 
-ifeq ($(ICU_FLAGS),"")
-  $(error ICU_FLAGS not set, is pkg-config installed?)
-endif
-
-ifeq ($(ICU_LIBS),"")
+ifeq ($(ICU_LIBS),)
   $(error ICU_LIBS not set, is pkg-config installed?)
 endif
 


### PR DESCRIPTION
Only `ICU_LIBS` has a value on *nix systems (tested on debian [bullseye docker image](https://hub.docker.com/layers/library/debian/bullseye-20230109-slim/images/sha256-1acb06a0c31fb467eb8327ad361f1091ab265e0bf26d452dea45dcb0c0ea5e75?context=explore)). I removed the check on `ICU_CFLAGS` and changed the test a bit so it actually fails when empty.

Typical output when pkg-config is unavailable is now, which indeed is a way better failure mode I think:
```
root@c975ea0d7a7c:/app# mix deps.compile ex_cldr_collation --force
==> ex_cldr_collation
make: pkg-config: No such file or directory
c_src/Makefile:57: *** ICU_LIBS not set, is pkg-config installed?.  Stop.
could not compile dependency :ex_cldr_collation, "mix compile" failed. Errors may have been logged above. You can recompile this dependency with "mix deps.compile ex_cldr_collation", update it with "mix deps.update ex_cldr_collation" or clean it with "mix deps.clean ex_cldr_collation"
==> cldr_collation_app
** (Mix) Could not compile with "make" (exit status: 2).
You need to have gcc and make installed. If you are using
Ubuntu or any other Debian-based system, install the packages
"build-essential". Also install "erlang-dev" package if not
included in your Erlang/OTP version. If you're on Fedora, run
"dnf group install 'Development Tools'".
```