### PR TITLE
Improve nif loading

### DIFF
--- a/lib/cldr_collation.ex
+++ b/lib/cldr_collation.ex
@@ -17,7 +17,7 @@ defmodule Cldr.Collation do
   def init do
     so_path = :code.priv_dir(:ex_cldr_collation) ++ '/ucol'
     num_scheds = :erlang.system_info(:schedulers)
-    :ok = :erlang.load_nif(so_path, num_scheds)
+    :erlang.load_nif(so_path, num_scheds)
   end
 
   @insensitive 1


### PR DESCRIPTION
I don't think matching makes sense in the context of the @on_load hook. This inflates the error message unnecessary.

from:
```elixir
13:30:54.037 [warning] The on_load function for module Elixir.Cldr.Collation returned:
{{:badmatch,
  {:error,
   {:load_failed,
    'Failed to load NIF library: \'/app/_build/prod/lib/ex_cldr_collation/priv/ucol.so: undefined symbol: ucol_strcollIter_67\''}}},
 [
   {Cldr.Collation, :init, 0, [file: 'lib/cldr_collation.ex', line: 20]},
   {:code_server, :"-handle_on_load/5-fun-0-", 1,
    [file: 'code_server.erl', line: 1317]}
 ]}


13:30:54.035 [error] Process #PID<0.242.0> raised an exception
** (MatchError) no match of right hand side value: {:error, {:load_failed, 'Failed to load NIF library: \'/app/_build/prod/lib/ex_cldr_collation/priv/ucol.so: undefined symbol: ucol_strcollIter_67\''}}
    lib/cldr_collation.ex:20: Cldr.Collation.init/0
    (kernel 8.5.3) code_server.erl:1317: anonymous fn/1 in :code_server.handle_on_load/5
```

to:
```erlang
13:31:26.290 [warning] The on_load function for module Elixir.Cldr.Collation returned:
{:error,
 {:load_failed,
  'Failed to load NIF library: \'/app/_build/prod/lib/ex_cldr_collation/priv/ucol.so: undefined symbol: ucol_strcollIter_67\''}}
```