### PR TITLE
Support all of icu_collator's CollatorOptions in the NIF API

### DIFF
--- a/native/ex_cldr_collation/src/collator_opts.rs
+++ b/native/ex_cldr_collation/src/collator_opts.rs
@@ -1,0 +1,152 @@
+/// Due to Rust's orphan rule, we can't implement NifMap directly on icu_collator::CollatorOptions.
+/// Furthermore, icu_collator::CollatorOptions is marked #[non_exhaustive], so we can't rely
+/// on its fields being stable.
+/// Thus we need to create our own version of CollatorOptions that we can use in our NIF API, and can be easily converted to icu_collator::ComparisonOptions.
+/// This also allows us the flexibily to adjust the NIF API if we so choose, while still being compatible with icu_collator.
+
+use rustler::{NifMap, NifUnitEnum};
+
+#[derive(NifUnitEnum)]
+pub enum Strength {
+    Primary,
+    Secondary,
+    Tertiary,
+    Quaternary,
+    Identical,
+}
+
+impl From<Strength> for icu_collator::Strength {
+    fn from(opts: Strength) -> Self {
+        match opts {
+            Strength::Primary => icu_collator::Strength::Primary,
+            Strength::Secondary => icu_collator::Strength::Secondary,
+            Strength::Tertiary => icu_collator::Strength::Tertiary,
+            Strength::Quaternary => icu_collator::Strength::Quaternary,
+            Strength::Identical => icu_collator::Strength::Identical,
+        }
+    }
+}
+
+#[derive(NifUnitEnum)]
+pub enum AlternateHandling {
+    NonIgnorable,
+    Shifted,
+}
+
+impl From<AlternateHandling> for icu_collator::AlternateHandling {
+    fn from(opts: AlternateHandling) -> Self {
+        match opts {
+            AlternateHandling::NonIgnorable => icu_collator::AlternateHandling::NonIgnorable,
+            AlternateHandling::Shifted => icu_collator::AlternateHandling::Shifted,
+        }
+    }
+}
+
+#[derive(NifUnitEnum)]
+pub enum CaseFirst {
+    Off,
+    LowerFirst,
+    UpperFirst,
+}
+
+impl From<CaseFirst> for icu_collator::CaseFirst {
+    fn from(opts: CaseFirst) -> Self {
+        match opts {
+            CaseFirst::Off => icu_collator::CaseFirst::Off,
+            CaseFirst::LowerFirst => icu_collator::CaseFirst::LowerFirst,
+            CaseFirst::UpperFirst => icu_collator::CaseFirst::UpperFirst,
+        }
+    }
+}
+
+#[derive(NifUnitEnum)]
+pub enum MaxVariable {
+    Space,
+    Punctuation,
+    Symbol,
+    Currency,
+}
+
+impl From<MaxVariable> for icu_collator::MaxVariable {
+    fn from(opts: MaxVariable) -> Self {
+        match opts {
+            MaxVariable::Space => icu_collator::MaxVariable::Space,
+            MaxVariable::Punctuation => icu_collator::MaxVariable::Punctuation,
+            MaxVariable::Symbol => icu_collator::MaxVariable::Symbol,
+            MaxVariable::Currency => icu_collator::MaxVariable::Currency,
+        }
+    }
+}
+
+#[derive(NifUnitEnum)]
+pub enum CaseLevel {
+    Off,
+    On,
+}
+
+impl From<CaseLevel> for icu_collator::CaseLevel {
+    fn from(opts: CaseLevel) -> Self {
+        match opts {
+            CaseLevel::Off => icu_collator::CaseLevel::Off,
+            CaseLevel::On => icu_collator::CaseLevel::On,
+        }
+    }
+}
+
+#[derive(NifUnitEnum)]
+pub enum Numeric {
+    Off,
+    On,
+}
+
+impl From<Numeric> for icu_collator::Numeric {
+    fn from(opts: Numeric) -> Self {
+        match opts {
+            Numeric::Off => icu_collator::Numeric::Off,
+            Numeric::On => icu_collator::Numeric::On,
+        }
+    }
+}
+
+#[derive(NifUnitEnum)]
+pub enum BackwardSecondLevel {
+    Off,
+    On,
+}
+
+impl From<BackwardSecondLevel> for icu_collator::BackwardSecondLevel {
+    fn from(opts: BackwardSecondLevel) -> Self {
+        match opts {
+            BackwardSecondLevel::Off => icu_collator::BackwardSecondLevel::Off,
+            BackwardSecondLevel::On => icu_collator::BackwardSecondLevel::On,
+        }
+    }
+}
+
+#[derive(NifMap)]
+pub struct CollatorOptions {
+    strength: Option<Strength>,
+    alternate_handling: Option<AlternateHandling>,
+    case_first: Option<CaseFirst>,
+    max_variable: Option<MaxVariable>,
+    case_level: Option<CaseLevel>,
+    numeric: Option<Numeric>,
+    backward_second_level: Option<BackwardSecondLevel>,
+}
+
+impl From<CollatorOptions> for icu_collator::CollatorOptions {
+    fn from(opts: CollatorOptions) -> Self {
+        let mut collator_options = icu_collator::CollatorOptions::new();
+
+        collator_options.strength = opts.strength.map(|s| s.into());
+        collator_options.alternate_handling = opts.alternate_handling.map(|a| a.into());
+        collator_options.case_first = opts.case_first.map(|c| c.into());
+        collator_options.max_variable = opts.max_variable.map(|m| m.into());
+        collator_options.case_level = opts.case_level.map(|c| c.into());
+        collator_options.numeric = opts.numeric.map(|n| n.into());
+        collator_options.backward_second_level = opts.backward_second_level.map(|b| b.into());
+
+        collator_options
+    }
+}
+

--- a/native/ex_cldr_collation/src/lib.rs
+++ b/native/ex_cldr_collation/src/lib.rs
@@ -1,36 +1,15 @@
+mod collator_opts;
+
 use icu_collator::*;
 use icu_locid::Locale;
-use rustler::{NifMap, NifResult, NifUnitEnum};
-
-#[derive(NifUnitEnum)]
-enum Casing {
-    Sensitive,
-    Insensitive,
-}
-
-#[derive(NifMap)]
-struct ComparisonOptions {
-    casing: Casing,
-}
-
-impl From<ComparisonOptions> for CollatorOptions {
-    fn from(opts: ComparisonOptions) -> Self {
-        let mut collator_options = CollatorOptions::new();
-
-        match opts.casing {
-            Casing::Insensitive => collator_options.strength = Some(Strength::Primary),
-            Casing::Sensitive => (),
-        }
-
-        collator_options
-    }
-}
+use collator_opts::CollatorOptions;
+use rustler::NifResult;
 
 #[rustler::nif]
 fn sort<'a>(
     locale_tag: &str,
     list: Vec<&'a str>,
-    opts: ComparisonOptions,
+    opts: CollatorOptions,
 ) -> NifResult<Vec<&'a str>> {
     let locale: Locale = locale_tag.parse().map_err(|_| rustler::Error::BadArg)?;
     let collator =


### PR DESCRIPTION
Building on #10, I've given our NIF API all the capabilities that `icu_collator` exposes, accepting a `CollatorOptions` that mirrors that which `icu_collator` uses. At the moment it's a one-to-one match, though that's within our control, and if we wanted a different API we could do that to. For now, however, I've just done the trivial thing, and I think that will serve us well. (But we might want to consider using `true` and `false` instead of `:on` and `:off` for `case_level`, `numeric`, and `backward_second_level`, or supporting both `true`/`false` and also `:on`/ `:off`.)

The Elixir typespec for the options the NIF API now expects is:
```elixir
%{
     strength: nil | :primary | :secondary | :tertiary | :quaternary | :identical,
     alternate_handling: nil | :non_ignorable | :shifted,
     case_first: nil | :off | :lower_first | :upper_first,
     max_variable: nil | :space | :punctuation | :symbol | :currency,
     case_level: nil | :off | :on,
     numeric: nil | :off | :on,
     backward_second_level: nil | :off | :on
 }
```

Note that all these keys are required. These get packed into a Rust struct and passed to the Rust side efficiently and without allocation, which is possible because there are a fixed number of fields. You could consider making a private Elixir struct for internal use, `defstruct [:strength, :alternate_handling, :case_first, :max_variable, :case_level, :numeric, :backward_second_level]`, and convert the user-supplied keyword list with `Kernel.struct/1`, which would ensure that all the fields are present and `nil` if not supplied—or however else you want to do it. Maybe even publicly expose the Elixir struct, if you think that could be helpful; or skip the struct and just use `Map.merge/2` to fill in the `nil`s.