### PR TITLE
Support creating Rust collator resource references usable from Elixir

### DIFF
--- a/lib/cldr_collation/nif.ex
+++ b/lib/cldr_collation/nif.ex
@@ -3,4 +3,6 @@ defmodule Cldr.Collation.Nif do
     otp_app: :ex_cldr_collation
 
   def sort(_locale, _list, _opts), do: :erlang.nif_error(:nif_not_loaded)
+  def sort_using_collator(_collator, _list), do: :erlang.nif_error(:nif_not_loaded)
+  def create_collator(_locale, _opts), do: :erlang.nif_error(:nif_not_loaded)
 end

--- a/native/ex_cldr_collation/Cargo.lock
+++ b/native/ex_cldr_collation/Cargo.lock
@@ -34,6 +34,7 @@ version = "0.1.0"
 dependencies = [
  "icu_collator",
  "icu_locid",
+ "icu_provider",
  "icu_testdata",
  "rustler",
 ]

--- a/native/ex_cldr_collation/Cargo.toml
+++ b/native/ex_cldr_collation/Cargo.toml
@@ -11,5 +11,6 @@ crate-type = ["cdylib"]
 [dependencies]
 icu_collator = "1.2.0"
 icu_locid = "1.2.0"
+icu_provider = { version = "1.2.0", features = ["sync"] }
 icu_testdata = "1.2.0"
 rustler = "0.28.0"

--- a/native/ex_cldr_collation/src/collator.rs
+++ b/native/ex_cldr_collation/src/collator.rs
@@ -1,0 +1,17 @@
+use icu_collator::Collator;
+use icu_locid::Locale;
+use rustler::NifResult;
+
+fn parse_locale(locale_tag: &str) -> NifResult<Locale> {
+    locale_tag.parse().map_err(|_| rustler::Error::BadArg)
+}
+
+pub fn new(
+    locale_tag: &str,
+    opts: impl Into<icu_collator::CollatorOptions>,
+) -> NifResult<Collator> {
+    let locale: Locale = parse_locale(locale_tag)?;
+    let collator =
+        Collator::try_new_unstable(&icu_testdata::unstable(), &locale.into(), opts.into()).unwrap();
+    Ok(collator)
+}

--- a/native/ex_cldr_collation/src/collator_opts.rs
+++ b/native/ex_cldr_collation/src/collator_opts.rs
@@ -3,7 +3,6 @@
 /// on its fields being stable.
 /// Thus we need to create our own version of CollatorOptions that we can use in our NIF API, and can be easily converted to icu_collator::ComparisonOptions.
 /// This also allows us the flexibily to adjust the NIF API if we so choose, while still being compatible with icu_collator.
-
 use rustler::{NifMap, NifUnitEnum};
 
 #[derive(NifUnitEnum)]
@@ -149,4 +148,3 @@ impl From<CollatorOptions> for icu_collator::CollatorOptions {
         collator_options
     }
 }
-

--- a/native/ex_cldr_collation/src/resource.rs
+++ b/native/ex_cldr_collation/src/resource.rs
@@ -1,0 +1,25 @@
+use icu_collator::Collator;
+use rustler::ResourceArc;
+use std::sync::Mutex;
+
+pub struct CollatorResource {
+    collator: Mutex<Collator>,
+}
+
+impl CollatorResource {
+    pub fn new(collator: Collator) -> Self {
+        Self {
+            collator: Mutex::new(collator),
+        }
+    }
+
+    pub fn new_arc(collator: Collator) -> ResourceArc<Self> {
+        ResourceArc::new(Self::new(collator))
+    }
+
+    pub fn collator(&self) -> &Mutex<Collator> {
+        &self.collator
+    }
+}
+
+pub type CollatorResourceArc = ResourceArc<CollatorResource>;


### PR DESCRIPTION
As described in #9, we want to also have an interface in which the user of the Elixir obtains a reference to a `Collator` Rust resource and uses it in multiple calls. This PR implements the NIF API for that interface.

This NIF API has a `create_collator/2` function that takes a locale and an options map and returns a reference that can be passed as the first argument to `sort_using_collator/2`. For example:

```elixir
collator = Cldr.Collation.Nif.create_collator("en", %{strength: :primary, alternate_handling: nil, case_first: nil, max_variable: nil, case_level: nil, numeric: nil, backward_second_level: nil})

assert Cldr.Collation.Nif.sort_using_collator(collator, ["AAAA", "AAAa"]) == ["AAAA", "AAAa"]
```